### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ reasons and unwritten ones.
 Set up
 ------
 
-    $ gem install sinatra
+    $ gem install sinatra webrick
     $ git clone https://github.com/authlete/useless-oauth-server
     $ cd useless-oauth-server
 


### PR DESCRIPTION
When I started the server, server.rb failed to start.

```
ruby server.rb
/home/sato/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rackup-2.2.0/lib/rackup/handler.rb:81:in `pick': Couldn't find handler for: puma, falcon, thin, HTTP, webrick. (LoadError)
```

I think we should add servers like webrick in README.md